### PR TITLE
MOT Benchmark Location as input

### DIFF
--- a/sort.py
+++ b/sort.py
@@ -233,6 +233,7 @@ def parse_args():
     """Parse input arguments."""
     parser = argparse.ArgumentParser(description='SORT demo')
     parser.add_argument('--display', dest='display', help='Display online tracker output (slow) [False]',action='store_true')
+    parser.add_argument('--benchmark', help='Pass the MOT benchmark location', required=True)
     args = parser.parse_args()
     return args
 
@@ -241,13 +242,14 @@ if __name__ == '__main__':
   sequences = ['PETS09-S2L1','TUD-Campus','TUD-Stadtmitte','ETH-Bahnhof','ETH-Sunnyday','ETH-Pedcross2','KITTI-13','KITTI-17','ADL-Rundle-6','ADL-Rundle-8','Venice-2']
   args = parse_args()
   display = args.display
+  benchmark = args.benchmark
   phase = 'train'
   total_time = 0.0
   total_frames = 0
   colours = np.random.rand(32,3) #used only for display
   if(display):
     if not os.path.exists('mot_benchmark'):
-      print('\n\tERROR: mot_benchmark link not found!\n\n    Create a symbolic link to the MOT benchmark\n    (https://motchallenge.net/data/2D_MOT_2015/#download). E.g.:\n\n    $ ln -s /path/to/MOT2015_challenge/2DMOT2015 mot_benchmark\n\n')
+      print('\n\tERROR: mot_benchmark link not found!\n\n    (https://motchallenge.net/data/2D_MOT_2015/#download)')
       exit()
     plt.ion()
     fig = plt.figure() 
@@ -268,7 +270,7 @@ if __name__ == '__main__':
 
         if(display):
           ax1 = fig.add_subplot(111, aspect='equal')
-          fn = 'mot_benchmark/%s/%s/img1/%06d.jpg'%(phase,seq,frame)
+          fn = os.path.join(benchmark,phase, seq, 'img1','{:06d}.jpg'.format(frame))
           im =io.imread(fn)
           ax1.imshow(im)
           plt.title(seq+' Tracked Targets')


### PR DESCRIPTION
Added argument to input the MOT benchmark location, instead of using the symbolic link